### PR TITLE
Disable global CORS and add separate CorsConfig

### DIFF
--- a/src/main/java/fr/bio/apiauthentication/config/CorsConfig.java
+++ b/src/main/java/fr/bio/apiauthentication/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package fr.bio.apiauthentication.config;
+
+import org.springframework.context.annotation.*;
+import org.springframework.web.cors.*;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+    @Bean
+    public CorsFilter corsFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:4200"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsFilter(source);
+    }
+}

--- a/src/main/java/fr/bio/apiauthentication/config/SecurityConfiguration.java
+++ b/src/main/java/fr/bio/apiauthentication/config/SecurityConfiguration.java
@@ -31,7 +31,6 @@ public class SecurityConfiguration {
     ) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
-                .cors(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry -> authorizationManagerRequestMatcherRegistry


### PR DESCRIPTION
Removed CORS configuration from SecurityConfiguration and created a dedicated CorsConfig class. This class now handles the CORS settings, specifying allowed origins, methods, and enabling credentials.