### PR TITLE
Disable CORS configuration in SecurityConfiguration

### DIFF
--- a/src/main/java/fr/bio/apiauthentication/config/SecurityConfiguration.java
+++ b/src/main/java/fr/bio/apiauthentication/config/SecurityConfiguration.java
@@ -33,7 +33,7 @@ public class SecurityConfiguration {
             HttpSecurity http
     ) throws Exception {
         http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .cors(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
This change disables CORS configuration explicitly in the SecurityConfiguration class. Now, CORS settings are not applied, which might be necessary for specific deployment environments or backend requirements. Ensure to verify that this change aligns with your security policies and front-end integration.